### PR TITLE
Fix K051960 RAM WEs (this matches the schematics).

### DIFF
--- a/sim/k051960.v
+++ b/sim/k051960.v
@@ -192,12 +192,12 @@ assign OD_out = DB_IN;
 
 // Internal RAM WEs
 wire Z95;
-assign RAM_A_WE = &{AB98, VBLANK_SYNC, Z95, ATTR_A[2:0] == 3'b001};
-assign RAM_B_WE = &{AB98, VBLANK_SYNC, Z95, ATTR_A[2:0] == 3'b010};
+assign RAM_A_WE = &{AB98, VBLANK_SYNC, Z95, ATTR_A[2:0] == 3'b110};
+assign RAM_B_WE = &{AB98, VBLANK_SYNC, Z95, ATTR_A[2:0] == 3'b101};
 assign RAM_C_WE = &{AB98, VBLANK_SYNC, Z95, ATTR_A[2:0] == 3'b011};
 assign RAM_D_WE = &{AB98, VBLANK_SYNC, Z95, ATTR_A[2:0] == 3'b100};
-assign RAM_E_WE = &{AB98, VBLANK_SYNC, Z95, ATTR_A[2:0] == 3'b101};
-assign RAM_F_WE = &{AB98, VBLANK_SYNC, Z95, ATTR_A[2:0] == 3'b110};
+assign RAM_E_WE = &{AB98, VBLANK_SYNC, Z95, ATTR_A[2:0] == 3'b010};
+assign RAM_F_WE = &{AB98, VBLANK_SYNC, Z95, ATTR_A[2:0] == 3'b001};
 assign RAM_G_WE = &{AB98, VBLANK_SYNC, Z95, ATTR_A[2:0] == 3'b111};
 
 // Internal RAM address - 8-to-1 bus mux


### PR DESCRIPTION
English:

Hello, furrtek. I am BueniaDev, and I am currently using your Konami IC schematics as a backbone for my Konami custom IC emulation library, [BeeKonami](https://github.com/BueniaDev/BeeKonami). While scanning your current Verilog translation of the K051960 chip, I noticed that a few of the internal RAM write enable registers didn't match the schematics. This pull request addresses that specific issue.

I mean, I don't know if you are currently accepting pull requests for this project, but I figured it might be worth a shot to try and contribute to the wider FPGA scene as a whole.

Thanks for reading this, and I hope you have a great day!

French:

Bonjour, furrtek. Je suis BueniaDev, et j'utilise actuellement vos schémas IC Konami comme colonne vertébrale pour ma bibliothèque d'émulation IC personnalisée Konami, [BeeKonami](https://github.com/BueniaDev/BeeKonami). Lors de la numérisation de votre traduction Verilog actuelle de la puce K051960, j'ai remarqué que quelques-uns des registres d'activation d'écriture de la RAM interne ne correspondaient pas aux schémas. Cette demande d'extraction résout ce problème spécifique.

Je veux dire, je ne sais pas si vous acceptez actuellement les demandes d'extraction pour ce projet, mais j'ai pensé que cela pourrait valoir la peine d'essayer de contribuer à la scène FPGA plus large dans son ensemble.

Merci d'avoir lu ceci, et j'espère que vous passerez une bonne journée !